### PR TITLE
Add Proxy Port Parameter

### DIFF
--- a/aiomqtt/client.py
+++ b/aiomqtt/client.py
@@ -88,6 +88,7 @@ class ProxySettings:
         proxy_rdns: bool | None = True,
         proxy_username: str | None = None,
         proxy_password: str | None = None,
+        proxy_port: int | None = None,
     ) -> None:
         self.proxy_args = {
             "proxy_type": proxy_type,
@@ -95,6 +96,7 @@ class ProxySettings:
             "proxy_rdns": proxy_rdns,
             "proxy_username": proxy_username,
             "proxy_password": proxy_password,
+            "proxy_port": proxy_port,
         }
 
 


### PR DESCRIPTION
This allows `proxy_port` to be passed to the underlying paho `proxy_set()` function call according to [the Paho MQTT docs](https://eclipse.dev/paho/files/paho.mqtt.python/html/client.html#paho.mqtt.client.Client.proxy_set). Also addresses https://github.com/empicano/aiomqtt/issues/337